### PR TITLE
fix for /admin showing error when user not logged

### DIFF
--- a/app/Http/Middleware/isAdmin.php
+++ b/app/Http/Middleware/isAdmin.php
@@ -16,9 +16,17 @@ class isAdmin
      */
     public function handle($request, Closure $next)
     {
+
         $user=Auth::user();
+        if($user){
+
+
         if(!$user->isAdmin()){
             return redirect('/');
+        }
+        }
+        else{
+            return redirect('/login');
         }
         return $next($request);
     }


### PR DESCRIPTION
small fix for /admin page showed error while user is null